### PR TITLE
Add automatic fallback naming for unknown Cozytouch capabilities

### DIFF
--- a/custom_components/cozytouch_cornutas/hub.py
+++ b/custom_components/cozytouch_cornutas/hub.py
@@ -390,6 +390,7 @@ class Hub(DataUpdateCoordinator):
                         modelInfos,
                         capability["capabilityId"],
                         capability["value"],
+                        capability,
                     )
 
                     if capability_infos is None and self._create_unknown:
@@ -408,10 +409,16 @@ class Hub(DataUpdateCoordinator):
         return capabilities
 
     def get_capability_infos(
-        self, modelId: int, capabilityId: int, capabilityValue: str
+        self,
+        modelId: int,
+        capabilityId: int,
+        capabilityValue: str,
+        capability_data: dict[str, Any] | None = None,
     ):
         """Get capability infos."""
-        return get_capability_infos(modelId, capabilityId, capabilityValue)
+        return get_capability_infos(
+            modelId, capabilityId, capabilityValue, capability_data
+        )
 
     def get_capability_value(
         self, capabilityId: int, defaultIfNotExist: str | None = "0"


### PR DESCRIPTION
## Summary
- derive sensor metadata for unknown Cozytouch capabilities from the API-provided definitions when no static mapping exists
- pass the full capability payload through the hub so the dynamic inference logic can inspect raw definition data

## Testing
- python -m compileall custom_components/cozytouch_cornutas

------
https://chatgpt.com/codex/tasks/task_e_68e137d6617c8328bd30aee175ce0b6c